### PR TITLE
Add support of RFC5987 for Content-Disposition

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -343,13 +343,27 @@ export function mapToList(map, keyNames="key", collectedKeys=Im.Map()) {
 }
 
 export function extractFileNameFromContentDispositionHeader(value){
-  let responseFilename = /filename="([^;]*);?"/i.exec(value)
-  if (responseFilename === null) {
-    responseFilename = /filename=([^;]*);?/i.exec(value)
-  }
+  let patterns = [
+    /filename\*=[^']+'\w*'"([^"]+)";?/i,
+    /filename\*=[^']+'\w*'([^;]+);?/i,
+    /filename="([^;]*);?"/i,
+    /filename=([^;]*);?/i
+  ]
+  
+  let responseFilename
+  patterns.some(regex => {
+    responseFilename = regex.exec(value)
+    return responseFilename !== null
+  })
+    
   if (responseFilename !== null && responseFilename.length > 1) {
-    return responseFilename[1]
+    try {
+      return decodeURIComponent(responseFilename[1])
+    } catch(e) {
+      console.error(e)
+    }
   }
+
   return null
 }
 


### PR DESCRIPTION
### Description
Implement an extractor for filenames encoded in RFC5987 style.

### Motivation and Context
At current moment, it is not possible to download a file named in UTF-8 encoding.

### How Has This Been Tested?
Manually tested on follow strings:

`attachment; filename*=UTF-8''"%D1%81%D0%B2%D0%B5%D0%B4%D0%B5%D0%BD%D0%B8%D1%8F.xlsx"`

`attachment; filename*=UTF-8''%D1%81%D0%B2%D0%B5%D0%B4%D0%B5%D0%BD%D0%B8%D1%8F.xlsx`

`attachment; filename="details.xlsx"`

`attachment; filename=details.xlsx`

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
